### PR TITLE
docs: fix correct answer for question linux on command

### DIFF
--- a/src/questions.js
+++ b/src/questions.js
@@ -3319,7 +3319,7 @@ export const questions = [
     },
     {
       "id": 243,
-      "question": "Which command lists all installed packages on a system using apt?",
+      "question": "Which command lists all installed packages on a Debian-based system using apt?",
       "options": [
         "apt list --installed",
         "dpkg -l",
@@ -3327,8 +3327,8 @@ export const questions = [
         "yum list installed",
         "pkg info"
       ],
-      "correct_answers": [1],
-      "explanation": "The 'dpkg -l' command lists all installed packages on Debian-based systems.",
+      "correct_answers": [0],
+      "explanation": "The 'apt list --installed' command lists all installed packages on Debian-based systems.",
       "question_type": "single-choice"
     },
     {


### PR DESCRIPTION
The question about command that lists all installed packages configured with incorrect answer. This change updates the question to correct command.

closes #3