### PR TITLE
docs: reword answer for question 154

### DIFF
--- a/src/questions.js
+++ b/src/questions.js
@@ -2146,13 +2146,13 @@ export const questions = [
       "question": "What is the purpose of the 'allowPrivilegeEscalation' securityContext field?",
       "options": [
         "Allows the container to run as root",
-        "Prevents the container from gaining more privileges than its parent process",
+        "Controls whether a process can gain more privileges than its parent process",
         "Enables privileged mode for the container",
         "Allows mounting of host directories",
         "Disables all capabilities for the container"
       ],
       "correct_answers": [1],
-      "explanation": "Setting 'allowPrivilegeEscalation' to false prevents processes from gaining more privileges than the parent.",
+      "explanation": "Setting 'allowPrivilegeEscalation' to false prevents processes from gaining more privileges than the parent. It's always true when the container is run as privileged or has CAP_SYS_ADMIN capability.",
       "question_type": "single-choice"
     },
     {


### PR DESCRIPTION
This PR rewords the answer for question id 154.

The question asked is "What is the purpose of the 'allowPrivilegeEscalation' securityContext field?". Right now the correct answer is worded as "Prevents the container from gaining more privileges than its parent process". This isn't really the "purpose" in my opinion; that's more of the outcome (desired from security perspective) if the option is set to `false`. I've reworded the answer as "Controls whether a process can gain more privileges than its parent process". It's taken from the [kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).

> `allowPrivilegeEscalation`: Controls whether a process can gain more privileges than its parent process. This bool directly controls whether the [`no_new_privs`](https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt) flag gets set on the container process. `allowPrivilegeEscalation` is always true when the container:
>
> - is run as privileged, or
> - has CAP_SYS_ADMIN

Also expanded the explanation of the answer using the snippet above.
