### PR TITLE
update question #3

### DIFF
--- a/src/exported-questions/Kubernetes_Security_Fundamentals.js
+++ b/src/exported-questions/Kubernetes_Security_Fundamentals.js
@@ -57,14 +57,27 @@ export const KubernetesSecurityFundamentalsQuestions = [
     "correct_answers": [
       1
     ],
-    "explanation": "PSA policies are applied per namespace using labels; only one policy level can be enforced per namespace.",
+    "explanation": "PSA policies are applied at the namespace level. While multiple labels can be applied to a namespace, each label corresponds to a specific mode (enforce, audit, or warn), and only one PSA policy level (privileged, baseline, or restricted) can be enforced per namespace for each mode. This ensures clear and consistent policy enforcement.",
     "question_type": "single-choice",
     "domain": "Kubernetes Security Fundamentals",
     "subdomain": "Pod Security Admissions",
-    "sources": [],
+    "sources": [
+      {
+        "name": "Kubernetes Documentation",
+        "url": "https://kubernetes.io/docs/concepts/security/pod-security-admission/"
+      },
+      {
+        "name": "Red Hat Documentation",
+        "url": "https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/authentication_and_authorization/understanding-and-managing-pod-security-admission"
+      },
+      {
+        "name": "Innablr Blog",
+        "url": "https://www.innablr.com.au/blog/kubernetes-pod-security-using-podsecuritystandards"
+      }
+    ],
     "revision": 0,
     "revision_date": null
-  },
+  },  
   {
     "id": 4,
     "question": "Which of the following restrictions does the 'baseline' Pod Security Standard enforce? (Select all that apply)",


### PR DESCRIPTION
**What was changed:**

- Corrected the explanation to clarify that while multiple labels can be applied to a namespace, only one PSA policy level can be enforced per namespace for each mode.
- Added relevant sources from Kubernetes and Red Hat documentation as well as a blog post for further reference.

**Why the change was needed:**
- The previous explanation was unclear and potentially misleading regarding the application of multiple PSA policy levels in a single namespace. This update ensures accuracy and provides proper citations for users to verify the information.